### PR TITLE
chore: update traefik and portainer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ###🚀 Auto-Instalador Docker Swarm + Traefik + Portainer
-Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto facilita a instalação do Docker Swarm, configuração de rede, Traefik e Portainer, reduzindo o tempo de deploy e garantindo um setup otimizado.
+Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto facilita a instalação do Docker Swarm, configuração de rede, Traefik e Portainer, reduzindo o tempo de deploy e garantindo um setup otimizado. Agora utiliza as versões mais recentes das ferramentas, incluindo **Traefik 3.5.1** e **Portainer CE 2.33.1**.
 
 <br>
 📌 Pré-requisitos

--- a/install_docker_swarm.sh
+++ b/install_docker_swarm.sh
@@ -44,7 +44,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:2.11.2
+    image: traefik:3.5.1
     command:
       - "--api.dashboard=true"
       - "--providers.docker.swarmMode=true"
@@ -122,7 +122,7 @@ version: "3.7"
 
 services:
   agent:
-    image: portainer/agent:2.20.1
+    image: portainer/agent:2.33.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
@@ -134,7 +134,7 @@ services:
         constraints: [node.platform.os == linux]
 
   portainer:
-    image: portainer/portainer-ce:2.20.1
+    image: portainer/portainer-ce:2.33.1
     command: -H tcp://tasks.agent:9001 --tlsskipverify
     volumes:
       - portainer_data:/data


### PR DESCRIPTION
## Summary
- bump Traefik image to 3.5.1
- use Portainer agent and CE 2.33.1
- document current component versions in README

## Testing
- `bash -n install_docker_swarm.sh`
- `shellcheck install_docker_swarm.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bdae7c50988324a8c09d197f874f52