### PR TITLE
feat: add n8n installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-###🚀 Auto-Instalador Docker Swarm + Traefik + Portainer
-Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto facilita a instalação do Docker Swarm, configuração de rede, Traefik e Portainer, reduzindo o tempo de deploy e garantindo um setup otimizado.
+###🚀 Auto-Instalador Docker Swarm + Traefik + Portainer + n8n
+Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto facilita a instalação do Docker Swarm, configuração de rede, Traefik, Portainer e n8n, reduzindo o tempo de deploy e garantindo um setup otimizado. Agora utiliza as versões mais recentes das ferramentas, incluindo **Traefik 3.5.1** e **Portainer CE 2.33.1**.
 
 <br>
 📌 Pré-requisitos
@@ -51,6 +51,15 @@ Agora, basta rodar o comando abaixo para iniciar a instalação:
 ```
 
 <br>
+6️⃣ (Opcional) Instale o n8n
+Se desejar utilizar o n8n, execute o script abaixo após concluir a instalação anterior:
+
+```bash
+chmod +x install_n8n.sh
+./install_n8n.sh
+```
+
+<br>
 <br>
 🔍 O que este script faz?
 <br>✅ Instalação automática do Docker Swarm
@@ -58,6 +67,7 @@ Agora, basta rodar o comando abaixo para iniciar a instalação:
 <br>✅ Configuração do Traefik com suporte a SSL via Let's Encrypt
 <br>✅ Deploy automático do Portainer para gerenciamento do Docker
 <br>✅ Geração dinâmica de arquivos traefik.yaml e portainer.yaml
+<br>✅ Deploy opcional do n8n integrado ao Traefik
 
 <br>
 <br>

--- a/install_docker_swarm.sh
+++ b/install_docker_swarm.sh
@@ -44,7 +44,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:2.11.2
+    image: traefik:3.5.1
     command:
       - "--api.dashboard=true"
       - "--providers.docker.swarmMode=true"
@@ -122,7 +122,7 @@ version: "3.7"
 
 services:
   agent:
-    image: portainer/agent:2.20.1
+    image: portainer/agent:2.33.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
@@ -134,7 +134,7 @@ services:
         constraints: [node.platform.os == linux]
 
   portainer:
-    image: portainer/portainer-ce:2.20.1
+    image: portainer/portainer-ce:2.33.1
     command: -H tcp://tasks.agent:9001 --tlsskipverify
     volumes:
       - portainer_data:/data

--- a/install_n8n.sh
+++ b/install_n8n.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e  # Interrompe a execução em caso de erro
+set -x  # Mostra cada comando antes de ser executado
+
+# Solicita o nome da rede já existente
+read -p "Digite o nome da rede pública existente: " NETWORK_NAME
+
+# Solicita domínio para o n8n
+read -p "Digite o domínio para o n8n: " N8N_DOMAIN
+
+# Solicita credenciais básicas
+read -p "Digite o usuário para o n8n (auth básica): " N8N_USER
+read -s -p "Digite a senha para o n8n (auth básica): " N8N_PASSWORD
+echo
+
+echo "Criando arquivo n8n.yaml..."
+cat <<EOT > n8n.yaml
+version: "3.7"
+
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=$N8N_USER
+      - N8N_BASIC_AUTH_PASSWORD=$N8N_PASSWORD
+      - N8N_HOST=$N8N_DOMAIN
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=https
+      - WEBHOOK_URL=https://$N8N_DOMAIN/
+    volumes:
+      - n8n_data:/home/node/.n8n
+    networks:
+      - $NETWORK_NAME
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+      labels:
+        - "traefik.enable=true"
+        - "traefik.docker.network=$NETWORK_NAME"
+        - "traefik.http.routers.n8n.rule=Host(\`$N8N_DOMAIN\`)"
+        - "traefik.http.routers.n8n.entrypoints=websecure"
+        - "traefik.http.routers.n8n.tls.certresolver=letsencryptresolver"
+        - "traefik.http.services.n8n.loadbalancer.server.port=5678"
+
+networks:
+  $NETWORK_NAME:
+    external: true
+
+volumes:
+  n8n_data:
+    external: false
+    name: n8n_data
+EOT
+
+# Verificando se o Traefik está rodando antes de iniciar o deploy do n8n
+if docker service ls | grep -q "traefik_traefik"; then
+    echo "Traefik está rodando. Continuando com o deploy do n8n..."
+else
+    echo "Erro: O Traefik ainda não está rodando! Aguarde e tente novamente."
+    exit 1
+fi
+
+# Deploy do n8n
+print_deploy_msg() {
+    echo "Fazendo deploy do n8n..."
+}
+print_deploy_msg
+docker stack deploy --prune --resolve-image always -c n8n.yaml n8n || { echo "Erro ao fazer deploy do n8n"; exit 1; }
+
+echo "✅ n8n implantado! Acesse: https://$N8N_DOMAIN"


### PR DESCRIPTION
## Summary
- bump Traefik image to 3.5.1
- use Portainer agent and CE 2.33.1
- document current component versions in README
- add install_n8n.sh script and docs for optional n8n deployment

## Testing
- `bash -n install_docker_swarm.sh install_n8n.sh`
- `shellcheck install_docker_swarm.sh install_n8n.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdae7c50988324a8c09d197f874f52