### PR TITLE
feat: add n8n, evolution api, and postgresql installer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,51 @@
-###🚀 Auto-Instalador Docker Swarm + Traefik + Portainer
-Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto facilita a instalação do Docker Swarm, configuração de rede, Traefik e Portainer, reduzindo o tempo de deploy e garantindo um setup otimizado.
+# 🚀 Auto-Instalador Docker Swarm + Traefik + Portainer + n8n + Evolution API + PostgreSQL
 
-<br>
-📌 Pré-requisitos
-Antes de começar, certifique-se de estar utilizando um sistema Linux compatível com Docker Swarm.
+Automatize a configuração do seu ambiente Docker Swarm com um único script! Este projeto instala e integra **Traefik 3.5.1**, **Portainer CE 2.33.1**, **n8n**, **Evolution API (latest)** e **PostgreSQL (latest)** utilizando sempre as imagens mais recentes.
 
-<br>
-🛠️ Passo a passo para instalação
-Siga os passos abaixo para configurar seu ambiente automaticamente.
+## 📌 Pré-requisitos
+- Sistema Linux compatível com Docker
+- Acesso root ou sudo
 
-<br>
-<br>
-1️⃣ Instale o Git
-Se ainda não tem o Git instalado, execute o seguinte comando no terminal:
+## 🛠️ Passo a passo
+1. **Instale o Git**
+   ```bash
+   apt install git -y
+   ```
+2. **Clone o repositório e acesse a pasta**
+   ```bash
+   git clone https://github.com/inovaboost/Auto-instalador-docker.git
+   cd Auto-instalador-docker
+   ```
+3. **Dê permissão de execução aos scripts**
+   ```bash
+   chmod +x install_docker_swarm.sh install_n8n.sh install_evolution_api.sh install_postgresql.sh
+   ```
+4. **Execute o instalador principal**
+   ```bash
+   ./install_docker_swarm.sh
+   ```
+5. **(Opcional) Instale o n8n**
+   ```bash
+   ./install_n8n.sh
+   ```
+6. **(Opcional) Instale o Evolution API**
+   ```bash
+   ./install_evolution_api.sh
+   ```
+7. **(Opcional) Instale o PostgreSQL**
+   ```bash
+   ./install_postgresql.sh
+   ```
 
-```bash
-apt install git -y
-```
+## 🔍 O que este instalador faz?
+- Instalação automática do Docker Swarm
+  - Criação de rede overlay attachable personalizada (sem status "limited" no Portainer)
+- Configuração do Traefik 3 (Swarm provider) com Let's Encrypt
+- Deploy do Portainer para gerenciamento
+- Deploy opcional do n8n, Evolution API e PostgreSQL
 
-<br>
-2️⃣ Faça o clone do repositório
-Baixe o script diretamente do nosso repositório no GitHub:
+## 📢 Atenção
+- Durante a execução, serão solicitados nome da rede, e-mail para SSL e domínio do Portainer. Informe-os corretamente.
+- Após a instalação, aguarde ~30 segundos antes de acessar o Portainer.
 
-```bash
-git clone https://github.com/inovaboost/Auto-instalador-docker.git
-```
-
-<br>
-3️⃣ Acesse a pasta do script
-Entre na pasta do repositório para poder executar os arquivos:
-
-```bash
-cd Auto-instalador-docker
-```
-
-<br>
-4️⃣ Dê permissão de execução ao script
-Antes de rodá-lo, é necessário garantir que o arquivo tenha permissões para execução:
-
-```bash
-chmod +x install_docker_swarm.sh
-```
-
-<br>
-5️⃣ Execute o script de instalação
-Agora, basta rodar o comando abaixo para iniciar a instalação:
-
-```bash
-./install_docker_swarm.sh
-```
-
-<br>
-<br>
-🔍 O que este script faz?
-<br>✅ Instalação automática do Docker Swarm
-<br>✅ Criação de rede overlay personalizada
-<br>✅ Configuração do Traefik com suporte a SSL via Let's Encrypt
-<br>✅ Deploy automático do Portainer para gerenciamento do Docker
-<br>✅ Geração dinâmica de arquivos traefik.yaml e portainer.yaml
-
-<br>
-<br>
-📢 Atenção
-- Durante a execução, o script pedirá algumas informações, como nome da rede, e-mail para SSL, e domínio do Portainer. Certifique-se de fornecer corretamente esses dados!
-- Após o término da instalação, aguarde cerca de 30 segundos antes de acessar o Portainer pelo navegador.
-🔗 Acesse o Portainer usando o domínio que você configurou durante a instalação!
-
-<br>
-<br>
-💡 Dúvidas ou sugestões?
-Contribua com o projeto no GitHub ou entre em contato! 🚀
-
+💡 Contribua com o projeto no GitHub ou entre em contato para dúvidas e sugestões!

--- a/install_docker_swarm.sh
+++ b/install_docker_swarm.sh
@@ -31,11 +31,11 @@ else
 fi
 
 # Solicita o nome da rede ao usuário
-read -p "Digite o nome da rede pública: " NETWORK_NAME
+read -r -p "Digite o nome da rede pública: " NETWORK_NAME
 
-# Criando a rede overlay
+# Criando a rede overlay attachable
 echo "Criando rede overlay..."
-docker network create --driver=overlay "$NETWORK_NAME" || { echo "Erro ao criar a rede"; exit 1; }
+docker network create --driver=overlay --attachable "$NETWORK_NAME" || { echo "Erro ao criar a rede"; exit 1; }
 
 # Criando traefik.yaml com todas as configurações corretas
 echo "Criando arquivo traefik.yaml..."
@@ -44,13 +44,13 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:2.11.2
+    image: traefik:3.5.1
     command:
       - "--api.dashboard=true"
-      - "--providers.docker.swarmMode=true"
-      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
-      - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=$NETWORK_NAME"
+      - "--providers.swarm=true"
+      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
+      - "--providers.swarm.exposedbydefault=false"
+      - "--providers.swarm.network=$NETWORK_NAME"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
@@ -75,7 +75,7 @@ services:
         - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
         - "traefik.http.routers.http-catchall.rule=hostregexp(\`{host:.+}\`)"
         - "traefik.http.routers.http-catchall.entrypoints=web"
-        - "traefik.http.routers.http-catchall.middlewares=redirect-https@docker"
+        - "traefik.http.routers.http-catchall.middlewares=redirect-https@swarm"
         - "traefik.http.routers.http-catchall.priority=1"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
@@ -105,7 +105,7 @@ networks:
 EOF
 
 # Solicita o e-mail do usuário para certificados SSL
-read -p "Digite seu e-mail para SSL (Let's Encrypt): " USER_EMAIL
+read -r -p "Digite seu e-mail para SSL (Let's Encrypt): " USER_EMAIL
 sed -i "s|(EMAIL_DO_USUARIO)|$USER_EMAIL|g" traefik.yaml
 
 # Deploy do Traefik
@@ -122,7 +122,7 @@ version: "3.7"
 
 services:
   agent:
-    image: portainer/agent:2.20.1
+    image: portainer/agent:2.33.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
@@ -134,7 +134,7 @@ services:
         constraints: [node.platform.os == linux]
 
   portainer:
-    image: portainer/portainer-ce:2.20.1
+    image: portainer/portainer-ce:2.33.1
     command: -H tcp://tasks.agent:9001 --tlsskipverify
     volumes:
       - portainer_data:/data
@@ -147,7 +147,7 @@ services:
         constraints: [node.role == manager]
       labels:
         - "traefik.enable=true"
-        - "traefik.docker.network=$NETWORK_NAME"
+        - "traefik.swarm.network=$NETWORK_NAME"
         - "traefik.http.routers.portainer.rule=Host(\`DOMINIO_DO_USUARIO\`)"
         - "traefik.http.routers.portainer.entrypoints=websecure"
         - "traefik.http.routers.portainer.priority=1"
@@ -158,7 +158,6 @@ services:
 networks:
   $NETWORK_NAME:
     external: true
-    attachable: true
     name: $NETWORK_NAME
 
 volumes:
@@ -168,7 +167,7 @@ volumes:
 EOF
 
 # Solicita domínio ao usuário
-read -p "Digite seu domínio para acesso ao Portainer: " USER_DOMAIN
+read -r -p "Digite seu domínio para acesso ao Portainer: " USER_DOMAIN
 sed -i "s|DOMINIO_DO_USUARIO|$USER_DOMAIN|g" portainer.yaml
 
 # Verificando se o Traefik está rodando antes de iniciar o deploy do Portainer

--- a/install_evolution_api.sh
+++ b/install_evolution_api.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -e  # Interrompe a execução em caso de erro
+set -x  # Mostra cada comando antes de ser executado
+
+# Solicita o nome da rede já existente
+read -r -p "Digite o nome da rede pública existente: " NETWORK_NAME
+
+# Solicita domínio para o Evolution API
+read -r -p "Digite o domínio para o Evolution API: " EVO_DOMAIN
+
+# Solicita credenciais para o banco de dados PostgreSQL
+read -r -p "Digite o usuário do banco de dados: " POSTGRES_USER
+read -r -s -p "Digite a senha do banco de dados: " POSTGRES_PASSWORD
+echo
+read -r -p "Digite o nome do banco de dados: " POSTGRES_DB
+
+echo "Criando arquivo evolution.yaml..."
+cat <<EOT > evolution.yaml
+version: "3.8"
+
+services:
+  api:
+    image: evoapicloud/evolution-api:latest
+    environment:
+      - SERVER_TYPE=https
+      - SERVER_PORT=8080
+      - SERVER_URL=https://$EVO_DOMAIN
+      - DATABASE_PROVIDER=postgresql
+      - DATABASE_CONNECTION_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:5432/$POSTGRES_DB?schema=evolution_api
+      - POSTGRES_DATABASE=$POSTGRES_DB
+      - POSTGRES_USERNAME=$POSTGRES_USER
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+    volumes:
+      - evolution_instances:/evolution/instances
+    networks:
+      - $NETWORK_NAME
+    depends_on:
+      - redis
+      - postgres
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=$NETWORK_NAME"
+        - "traefik.http.routers.evolution.rule=Host(\`$EVO_DOMAIN\`)"
+        - "traefik.http.routers.evolution.entrypoints=websecure"
+        - "traefik.http.routers.evolution.tls.certresolver=letsencryptresolver"
+        - "traefik.http.services.evolution.loadbalancer.server.port=8080"
+
+  redis:
+    image: redis:latest
+    volumes:
+      - evolution_redis:/data
+    networks:
+      - $NETWORK_NAME
+
+  postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_DB=$POSTGRES_DB
+      - POSTGRES_USER=$POSTGRES_USER
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - $NETWORK_NAME
+
+networks:
+  $NETWORK_NAME:
+    external: true
+
+volumes:
+  evolution_instances:
+  evolution_redis:
+  postgres_data:
+EOT
+
+# Verificando se o Traefik está rodando antes de iniciar o deploy do Evolution API
+if docker service ls | grep -q "traefik_traefik"; then
+    echo "Traefik está rodando. Continuando com o deploy do Evolution API..."
+else
+    echo "Erro: O Traefik ainda não está rodando! Aguarde e tente novamente."
+    exit 1
+fi
+
+# Deploy do Evolution API
+print_deploy_msg() {
+    echo "Fazendo deploy do Evolution API..."
+}
+print_deploy_msg
+docker stack deploy --prune --resolve-image always -c evolution.yaml evolution || { echo "Erro ao fazer deploy do Evolution API"; exit 1; }
+
+echo "✅ Evolution API implantado! Acesse: https://$EVO_DOMAIN"

--- a/install_n8n.sh
+++ b/install_n8n.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e  # Interrompe a execução em caso de erro
+set -x  # Mostra cada comando antes de ser executado
+
+# Solicita o nome da rede já existente
+read -r -p "Digite o nome da rede pública existente: " NETWORK_NAME
+
+# Solicita domínio para o n8n
+read -r -p "Digite o domínio para o n8n: " N8N_DOMAIN
+
+# Solicita credenciais básicas
+read -r -p "Digite o usuário para o n8n (auth básica): " N8N_USER
+read -r -s -p "Digite a senha para o n8n (auth básica): " N8N_PASSWORD
+echo
+
+echo "Criando arquivo n8n.yaml..."
+cat <<EOT > n8n.yaml
+version: "3.7"
+
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=$N8N_USER
+      - N8N_BASIC_AUTH_PASSWORD=$N8N_PASSWORD
+      - N8N_HOST=$N8N_DOMAIN
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=https
+      - WEBHOOK_URL=https://$N8N_DOMAIN/
+    volumes:
+      - n8n_data:/home/node/.n8n
+    networks:
+      - $NETWORK_NAME
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=$NETWORK_NAME"
+        - "traefik.http.routers.n8n.rule=Host(\`$N8N_DOMAIN\`)"
+        - "traefik.http.routers.n8n.entrypoints=websecure"
+        - "traefik.http.routers.n8n.tls.certresolver=letsencryptresolver"
+        - "traefik.http.services.n8n.loadbalancer.server.port=5678"
+
+networks:
+  $NETWORK_NAME:
+    external: true
+
+volumes:
+  n8n_data:
+    external: false
+    name: n8n_data
+EOT
+
+# Verificando se o Traefik está rodando antes de iniciar o deploy do n8n
+if docker service ls | grep -q "traefik_traefik"; then
+    echo "Traefik está rodando. Continuando com o deploy do n8n..."
+else
+    echo "Erro: O Traefik ainda não está rodando! Aguarde e tente novamente."
+    exit 1
+fi
+
+# Deploy do n8n
+print_deploy_msg() {
+    echo "Fazendo deploy do n8n..."
+}
+print_deploy_msg
+docker stack deploy --prune --resolve-image always -c n8n.yaml n8n || { echo "Erro ao fazer deploy do n8n"; exit 1; }
+
+echo "✅ n8n implantado! Acesse: https://$N8N_DOMAIN"

--- a/install_postgresql.sh
+++ b/install_postgresql.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e  # Interrompe a execução em caso de erro
+set -x  # Mostra cada comando antes de ser executado
+
+# Solicita o nome da rede já existente
+read -r -p "Digite o nome da rede pública existente: " NETWORK_NAME
+
+# Solicita credenciais e banco de dados
+read -r -p "Digite o nome do banco de dados: " POSTGRES_DB
+read -r -p "Digite o usuário do banco de dados: " POSTGRES_USER
+read -r -s -p "Digite a senha do banco de dados: " POSTGRES_PASSWORD
+echo
+
+echo "Criando arquivo postgres.yaml..."
+cat <<EOT > postgres.yaml
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_DB=$POSTGRES_DB
+      - POSTGRES_USER=$POSTGRES_USER
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - $NETWORK_NAME
+    ports:
+      - target: 5432
+        published: 5432
+        protocol: tcp
+        mode: host
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+
+networks:
+  $NETWORK_NAME:
+    external: true
+
+volumes:
+  postgres_data:
+    external: false
+    name: postgres_data
+EOT
+
+echo "Fazendo deploy do PostgreSQL..."
+docker stack deploy --prune --resolve-image always -c postgres.yaml postgres || { echo "Erro ao fazer deploy do PostgreSQL"; exit 1; }
+
+echo "✅ PostgreSQL implantado! Porta 5432 exposta."


### PR DESCRIPTION
## Summary
- bump Traefik image to 3.5.1
- use Portainer agent and CE 2.33.1
- switch to Traefik v3 Swarm provider and update labels across scripts
- add install_n8n.sh, install_evolution_api.sh, and install_postgresql.sh for optional deployments
- configure an attachable overlay network to avoid Portainer's limited stack status

## Testing
- `bash -n install_docker_swarm.sh install_n8n.sh install_evolution_api.sh install_postgresql.sh && echo "bash syntax OK"`
- `shellcheck install_docker_swarm.sh install_n8n.sh install_evolution_api.sh install_postgresql.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdae7c50988324a8c09d197f874f52